### PR TITLE
Optimize parse_str_radix_n

### DIFF
--- a/benches/lib_benches.rs
+++ b/benches/lib_benches.rs
@@ -191,6 +191,16 @@ fn decimal_from_str(b: &mut test::Bencher) {
 }
 
 #[bench]
+fn decimal_from_str_radix_n(b: &mut test::Bencher) {
+    b.iter(|| {
+        for s in SAMPLE_STRS {
+            let result = Decimal::from_str_radix_n(s, 10).unwrap();
+            test::black_box(result);
+        }
+    })
+}
+
+#[bench]
 fn decimal_to_string(b: &mut test::Bencher) {
     let decimals: Vec<Decimal> = SAMPLE_STRS.iter().map(|s| Decimal::from_str(s).unwrap()).collect();
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1508,6 +1508,12 @@ impl Decimal {
             crate::str::parse_str_radix_n(str, radix)
         }
     }
+
+    #[doc(hidden)]
+    // Added for benchmarking performance difference from parse_str_radix_10
+    pub fn from_str_radix_n(str: &str, radix: u32) -> Result<Self, crate::Error> {
+        crate::str::parse_str_radix_n(str, radix)
+    }
 }
 
 impl Default for Decimal {

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -93,7 +93,7 @@ pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
     carry as u32
 }
 
-pub(crate) fn add_by_internal_flattened(value: &mut [u32; 3], by: u32) -> u32 {
+pub(crate) fn add_by_internal3(value: &mut [u32; 3], by: u32) -> u32 {
     let mut carry: u64;
     let mut sum: u64;
     sum = u64::from(value[0]) + u64::from(by);

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -93,25 +93,6 @@ pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
     carry as u32
 }
 
-pub(crate) fn add_by_internal3(value: &mut [u32; 3], by: u32) -> u32 {
-    let mut carry: u64;
-    let mut sum: u64;
-    sum = u64::from(value[0]) + u64::from(by);
-    value[0] = (sum & U32_MASK) as u32;
-    carry = sum >> 32;
-    if carry > 0 {
-        sum = u64::from(value[1]) + carry;
-        value[1] = (sum & U32_MASK) as u32;
-        carry = sum >> 32;
-        if carry > 0 {
-            sum = u64::from(value[2]) + carry;
-            value[2] = (sum & U32_MASK) as u32;
-            carry = sum >> 32;
-        }
-    }
-    carry as u32
-}
-
 #[inline]
 pub(crate) fn add_one_internal(value: &mut [u32]) -> u32 {
     let mut carry: u64 = 1; // Start with one, since adding one

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{BYTES_TO_OVERFLOW_U64, MAX_PRECISION, MAX_STR_BUFFER_SIZE, OVERFLOW_U96, WILL_OVERFLOW_U64},
     error::{tail_error, Error},
-    ops::array::{add_by_internal3, add_one_internal, div_by_u32, is_all_zero, mul_by_u32},
+    ops::array::{div_by_u32, is_all_zero},
     Decimal,
 };
 
@@ -358,11 +358,8 @@ fn handle_data<const NEG: bool, const HAS: bool>(data: u128, scale: u8) -> Resul
         ))
     }
 }
-
+#[inline]
 pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate::Error> {
-    if str.is_empty() {
-        return Err(Error::from("Invalid decimal: empty"));
-    }
     if radix < 2 {
         return Err(Error::from("Unsupported radix < 2"));
     }
@@ -371,38 +368,48 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
         return Err(Error::from("Unsupported radix > 36"));
     }
 
-    let mut offset = 0;
-    let mut len = str.len();
-    let bytes = str.as_bytes();
-    let mut negative = false; // assume positive
-
-    // handle the sign
-    if bytes[offset] == b'-' {
-        negative = true; // leading minus means negative
-        offset += 1;
-        len -= 1;
-    } else if bytes[offset] == b'+' {
-        // leading + allowed
-        offset += 1;
-        len -= 1;
+    match radix {
+        2 => parse_str_radix_const::<2>(str),
+        3 => parse_str_radix_const::<3>(str),
+        4 => parse_str_radix_const::<4>(str),
+        5 => parse_str_radix_const::<5>(str),
+        6 => parse_str_radix_const::<6>(str),
+        7 => parse_str_radix_const::<7>(str),
+        8 => parse_str_radix_const::<8>(str),
+        9 => parse_str_radix_const::<9>(str),
+        10 => parse_str_radix_const::<10>(str),
+        11 => parse_str_radix_const::<11>(str),
+        12 => parse_str_radix_const::<12>(str),
+        13 => parse_str_radix_const::<13>(str),
+        14 => parse_str_radix_const::<14>(str),
+        15 => parse_str_radix_const::<15>(str),
+        16 => parse_str_radix_const::<16>(str),
+        17 => parse_str_radix_const::<17>(str),
+        18 => parse_str_radix_const::<18>(str),
+        19 => parse_str_radix_const::<19>(str),
+        20 => parse_str_radix_const::<20>(str),
+        21 => parse_str_radix_const::<21>(str),
+        22 => parse_str_radix_const::<22>(str),
+        23 => parse_str_radix_const::<23>(str),
+        24 => parse_str_radix_const::<24>(str),
+        25 => parse_str_radix_const::<25>(str),
+        26 => parse_str_radix_const::<26>(str),
+        27 => parse_str_radix_const::<27>(str),
+        28 => parse_str_radix_const::<28>(str),
+        29 => parse_str_radix_const::<29>(str),
+        30 => parse_str_radix_const::<30>(str),
+        31 => parse_str_radix_const::<31>(str),
+        32 => parse_str_radix_const::<32>(str),
+        33 => parse_str_radix_const::<33>(str),
+        34 => parse_str_radix_const::<34>(str),
+        35 => parse_str_radix_const::<35>(str),
+        36 => parse_str_radix_const::<36>(str),
+        _ => unreachable!(),
     }
+}
 
-    // should now be at numeric part of the significand
-    let mut digits_before_dot: i32 = -1; // digits before '.', -1 if no '.'
-    let mut coeff = ArrayVec::<_, 96>::new(); // integer significand array
-
-    // Supporting different radix
-    let (max_n, max_alpha_lower, max_alpha_upper) = if radix <= 10 {
-        (b'0' + (radix - 1) as u8, 0, 0)
-    } else {
-        let adj = (radix - 11) as u8;
-        (b'9', adj + b'a', adj + b'A')
-    };
-
-    // Estimate the max precision. All in all, it needs to fit into 96 bits.
-    // Rather than try to estimate, I've included the constants directly in here. We could,
-    // perhaps, replace this with a formula if it's faster - though it does appear to be log2.
-    let estimated_max_precision = match radix {
+const fn estimated_max_precision(radix: u8) -> u8 {
+    match radix {
         2 => 96,
         3 => 61,
         4 => 48,
@@ -438,186 +445,229 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
         34 => 19,
         35 => 19,
         36 => 19,
-        _ => return Err(Error::from("Unsupported radix")),
+        _ => 0xFF,
+    }
+}
+
+#[inline]
+pub(crate) fn parse_str_radix_const<const RADIX: u8>(str: &str) -> Result<Decimal, crate::Error> {
+    if str.is_empty() {
+        return Err(Error::from("Invalid decimal: empty"));
+    }
+    debug_assert!(RADIX >= 2);
+    debug_assert!(RADIX <= 36);
+
+    let mut bytes = str.as_bytes();
+    let mut negative = false; // assume positive
+
+    // handle the sign
+
+    bytes = match bytes[0] {
+        b'-' => {
+            negative = true; // leading minus means negative
+            &bytes[1..]
+        }
+        b'+' => {
+            // leading + allowed
+            &bytes[1..]
+        }
+        _ => bytes,
     };
 
-    let mut maybe_round = false;
-    while len > 0 {
-        let b = bytes[offset];
-        match b {
-            b'0'..=b'9' => {
-                if b > max_n {
-                    return Err(Error::from("Invalid decimal: invalid character"));
-                }
-                coeff.push(u32::from(b - b'0'));
-                offset += 1;
-                len -= 1;
+    // should now be at numeric part of the significand
+    let mut passed_decimal_point = false;
+    let mut has_digit = false;
+    let mut scale: u8 = 0;
+    let mut data64: u64 = 0;
 
-                // If the coefficient is longer than the max, exit early
-                if coeff.len() as u32 > estimated_max_precision {
-                    maybe_round = true;
-                    break;
-                }
-            }
-            b'a'..=b'z' => {
-                if b > max_alpha_lower {
-                    return Err(Error::from("Invalid decimal: invalid character"));
-                }
-                coeff.push(u32::from(b - b'a') + 10);
-                offset += 1;
-                len -= 1;
+    while data64 < (u64::MAX / RADIX as u64 - u8::MAX as u64) {
+        // we have already validated that we cannot overflow
+        if !bytes.is_empty() {
+            let b = bytes[0];
+            match b {
+                b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
+                    let digit = match b {
+                        b'0'..=b'9' => u32::from(b - b'0'),
+                        b'a'..=b'z' if RADIX > 10 => u32::from(b - b'a' + 10),
+                        b'A'..=b'Z' if RADIX > 10 => u32::from(b - b'A' + 10),
+                        _ => return Err(Error::from("Invalid decimal: invalid character")),
+                    };
+                    if digit >= RADIX as u32 {
+                        return Err(Error::from("Invalid decimal: invalid character"));
+                    }
+                    has_digit = true;
 
-                if coeff.len() as u32 > estimated_max_precision {
-                    maybe_round = true;
-                    break;
-                }
-            }
-            b'A'..=b'Z' => {
-                if b > max_alpha_upper {
-                    return Err(Error::from("Invalid decimal: invalid character"));
-                }
-                coeff.push(u32::from(b - b'A') + 10);
-                offset += 1;
-                len -= 1;
+                    data64 = data64 * RADIX as u64 + digit as u64;
+                    scale += passed_decimal_point as u8;
 
-                if coeff.len() as u32 > estimated_max_precision {
-                    maybe_round = true;
-                    break;
-                }
-            }
-            b'.' => {
-                if digits_before_dot >= 0 {
-                    return Err(Error::from("Invalid decimal: two decimal points"));
-                }
-                digits_before_dot = coeff.len() as i32;
-                offset += 1;
-                len -= 1;
-            }
-            b'_' => {
-                // Must start with a number...
-                if coeff.is_empty() {
-                    return Err(Error::from("Invalid decimal: must start lead with a number"));
-                }
-                offset += 1;
-                len -= 1;
-            }
-            _ => return Err(Error::from("Invalid decimal: unknown character")),
-        }
-    }
-
-    // If we exited before the end of the string then do some rounding if necessary
-    if maybe_round && offset < bytes.len() {
-        let next_byte = bytes[offset];
-        let digit = match next_byte {
-            b'0'..=b'9' => {
-                if next_byte > max_n {
-                    return Err(Error::from("Invalid decimal: invalid character"));
-                }
-                u32::from(next_byte - b'0')
-            }
-            b'a'..=b'z' => {
-                if next_byte > max_alpha_lower {
-                    return Err(Error::from("Invalid decimal: invalid character"));
-                }
-                u32::from(next_byte - b'a') + 10
-            }
-            b'A'..=b'Z' => {
-                if next_byte > max_alpha_upper {
-                    return Err(Error::from("Invalid decimal: invalid character"));
-                }
-                u32::from(next_byte - b'A') + 10
-            }
-            b'_' => 0,
-            b'.' => {
-                // Still an error if we have a second dp
-                if digits_before_dot >= 0 {
-                    return Err(Error::from("Invalid decimal: two decimal points"));
-                }
-                0
-            }
-            _ => return Err(Error::from("Invalid decimal: unknown character")),
-        };
-
-        // Round at midpoint
-        let midpoint = if radix & 0x1 == 1 { radix / 2 } else { (radix + 1) / 2 };
-        if digit >= midpoint {
-            let mut index = coeff.len() - 1;
-            loop {
-                let new_digit = coeff[index] + 1;
-                if new_digit <= 9 {
-                    coeff[index] = new_digit;
-                    break;
-                } else {
-                    coeff[index] = 0;
-                    if index == 0 {
-                        coeff.insert(0, 1u32);
-                        digits_before_dot += 1;
-                        coeff.pop();
+                    if scale >= estimated_max_precision(RADIX) {
+                        if !bytes.is_empty() {
+                            return maybe_round_radix::<RADIX>(
+                                data64 as u128,
+                                bytes[0],
+                                scale,
+                                passed_decimal_point,
+                                negative,
+                            );
+                        }
                         break;
                     }
                 }
-                index -= 1;
+                b'.' => {
+                    if passed_decimal_point {
+                        return Err(Error::from("Invalid decimal: two decimal points"));
+                    }
+                    passed_decimal_point = true;
+                }
+                b'_' => {
+                    // Must start with a number...
+                    if !has_digit {
+                        return Err(Error::from("Invalid decimal: must start lead with a number"));
+                    }
+                }
+                _ => return Err(Error::from("Invalid decimal: unknown character")),
             }
+            bytes = &bytes[1..];
+        } else {
+            break;
         }
     }
 
-    // here when no characters left
-    if coeff.is_empty() {
+    let data: u128 = data64 as u128;
+
+    if !bytes.is_empty() {
+        return handle_full_128_radix::<RADIX>(data, bytes, scale, passed_decimal_point, negative);
+    } else if !has_digit {
         return Err(Error::from("Invalid decimal: no digits found"));
     }
 
-    let mut scale = if digits_before_dot >= 0 {
-        // we had a decimal place so set the scale
-        (coeff.len() as u32) - (digits_before_dot as u32)
+    handle_data_radix(data, scale, negative)
+}
+
+const fn midpoint_for_radix(radix: u8) -> u8 {
+    if radix & 0x1 == 1 {
+        radix / 2
     } else {
-        0
-    };
+        (radix + 1) / 2
+    }
+}
 
-    // Parse this using specified radix
-    let mut data = [0u32, 0u32, 0u32];
-    let mut tmp = [0u32, 0u32, 0u32];
-    let len = coeff.len();
-    for (i, digit) in coeff.iter().enumerate() {
-        // If the data is going to overflow then we should go into recovery mode
-        tmp[0] = data[0];
-        tmp[1] = data[1];
-        tmp[2] = data[2];
-        let overflow = mul_by_u32(&mut tmp, radix);
-        if overflow > 0 {
-            // This means that we have more data to process, that we're not sure what to do with.
-            // This may or may not be an issue - depending on whether we're past a decimal point
-            // or not.
-            if (i as i32) < digits_before_dot && i + 1 < len {
-                return Err(Error::from("Invalid decimal: overflow from too many digits"));
-            }
+#[inline(never)]
+#[cold]
+fn handle_full_128_radix<const RADIX: u8>(
+    mut data: u128,
+    mut bytes: &[u8],
+    mut scale: u8,
+    mut passed_decimal_point: bool,
+    negative: bool,
+) -> Result<Decimal, crate::Error> {
+    while !bytes.is_empty() {
+        let b = bytes[0];
+        match b {
+            b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
+                let digit = match b {
+                    b'0'..=b'9' => u32::from(b - b'0'),
+                    b'a'..=b'z' if RADIX > 10 => u32::from(b - b'a' + 10),
+                    b'A'..=b'Z' if RADIX > 10 => u32::from(b - b'A' + 10),
+                    _ => return Err(Error::from("Invalid decimal: invalid character")),
+                };
+                if digit >= RADIX as u32 {
+                    return Err(Error::from("Invalid decimal: invalid character"));
+                }
 
-            if *digit >= 5 {
-                let carry = add_one_internal(&mut data);
-                if carry > 0 {
-                    // Highly unlikely scenario which is more indicative of a bug
-                    return Err(Error::from("Invalid decimal: overflow when rounding"));
+                // If the data is going to overflow then we should go into recovery mode
+                let next = data * RADIX as u128 + digit as u128;
+                if overflow_128(next) {
+                    // This means that we have more data to process, that we're not sure what to do with.
+                    // This may or may not be an issue - depending on whether we're past a decimal point
+                    // or not.
+                    if !passed_decimal_point {
+                        return Err(Error::from("Invalid decimal: overflow from too many digits"));
+                    }
+
+                    if digit >= midpoint_for_radix(RADIX) as u32 {
+                        data += 1;
+                    }
+                    break;
+                } else {
+                    data = next;
+                    scale += passed_decimal_point as u8;
+
+                    if scale >= estimated_max_precision(RADIX) {
+                        if !bytes.is_empty() {
+                            return maybe_round_radix::<RADIX>(
+                                data as u128,
+                                bytes[0],
+                                scale,
+                                passed_decimal_point,
+                                negative,
+                            );
+                        }
+                        break;
+                    }
                 }
             }
-            // We're also one less digit so reduce the scale
-            let diff = (len - i) as u32;
-            if diff > scale {
-                return Err(Error::from("Invalid decimal: overflow from scale mismatch"));
+            b'.' => {
+                if passed_decimal_point {
+                    return Err(Error::from("Invalid decimal: two decimal points"));
+                }
+                passed_decimal_point = true;
             }
-            scale -= diff;
-            break;
-        } else {
-            data[0] = tmp[0];
-            data[1] = tmp[1];
-            data[2] = tmp[2];
-            let carry = add_by_internal3(&mut data, *digit);
-            if carry > 0 {
-                // Highly unlikely scenario which is more indicative of a bug
-                return Err(Error::from("Invalid decimal: overflow from carry"));
+            b'_' => {}
+            _ => return Err(Error::from("Invalid decimal: unknown character")),
+        }
+        bytes = &bytes[1..];
+    }
+
+    handle_data_radix(data, scale, negative)
+}
+
+#[inline(never)]
+#[cold]
+fn maybe_round_radix<const RADIX: u8>(
+    mut data: u128,
+    next_byte: u8,
+    scale: u8,
+    passed_decimal_point: bool,
+    negative: bool,
+) -> Result<Decimal, crate::Error> {
+    let digit = match next_byte {
+        b'0'..=b'9' => u32::from(next_byte - b'0'),
+        b'a'..=b'z' if RADIX > 10 => u32::from(next_byte - b'a' + 10),
+        b'A'..=b'Z' if RADIX > 10 => u32::from(next_byte - b'A' + 10),
+        b'_' => 0, // this is a bug?
+        b'.' => {
+            // Still an error if we have a second dp
+            if passed_decimal_point {
+                return Err(Error::from("Invalid decimal: two decimal points"));
             }
+            0
+        }
+        _ => return Err(Error::from("Invalid decimal: unknown character")),
+    };
+
+    if digit >= RADIX as u32 {
+        return Err(Error::from("Invalid decimal: invalid character"));
+    }
+
+    // Round at midpoint
+    if digit >= midpoint_for_radix(RADIX) as u32 {
+        data += 1;
+        if overflow_128(data) {
+            // Highly unlikely scenario which is more indicative of a bug
+            return Err(Error::from("Invalid decimal: overflow when rounding"));
         }
     }
 
-    Ok(Decimal::from_parts(data[0], data[1], data[2], negative, scale))
+    handle_data_radix(data, scale, negative)
+}
+
+fn handle_data_radix(data: u128, scale: u8, negative: bool) -> Result<Decimal, crate::Error> {
+    debug_assert_eq!(data >> 96, 0);
+
+    let data = [data as u32, (data >> 32) as u32, (data >> 64) as u32];
+
+    Ok(Decimal::from_parts(data[0], data[1], data[2], negative, scale as u32))
 }
 
 #[cfg(test)]
@@ -637,182 +687,227 @@ mod test {
 
     #[test]
     fn from_str_rounding_0() {
+        let str = "1.234";
         assert_eq!(
-            parse_str_radix_10("1.234").unwrap().unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::new(1234, 3).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_rounding_1() {
+        let str = "11111_11111_11111.11111_11111_11111";
         assert_eq!(
-            parse_str_radix_10("11111_11111_11111.11111_11111_11111")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_111, 14).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_rounding_2() {
+        let str = "11111_11111_11111.11111_11111_11115";
         assert_eq!(
-            parse_str_radix_10("11111_11111_11111.11111_11111_11115")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_112, 14).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_rounding_3() {
+        let str = "11111_11111_11111.11111_11111_11195";
         assert_eq!(
-            parse_str_radix_10("11111_11111_11111.11111_11111_11195")
-                .unwrap()
-                .unpack(),
-            Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_1120, 14).unpack() // was Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_112, 13)
+            parse_str_radix_10(str).unwrap().unpack(),
+            Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_1120, 14).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_rounding_4() {
+        let str = "99999_99999_99999.99999_99999_99995";
         assert_eq!(
-            parse_str_radix_10("99999_99999_99999.99999_99999_99995")
-                .unwrap()
-                .unpack(),
-            Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 13).unpack() // was Decimal::from_i128_with_scale(1_000_000_000_000_000_000_000_000_000, 12)
+            parse_str_radix_10(str).unwrap().unpack(),
+            Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 13).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_many_pointless_chars() {
+        let str = "00________________________________________________________________001.1";
         assert_eq!(
-            parse_str_radix_10("00________________________________________________________________001.1")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(11, 1).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_leading_0s_1() {
+        let str = "00001.1";
         assert_eq!(
-            parse_str_radix_10("00001.1").unwrap().unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(11, 1).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_leading_0s_2() {
+        let str = "00000_00000_00000_00000_00001.00001";
         assert_eq!(
-            parse_str_radix_10("00000_00000_00000_00000_00001.00001")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(100001, 5).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_leading_0s_3() {
+        let str = "0.00000_00000_00000_00000_00000_00100";
         assert_eq!(
-            parse_str_radix_10("0.00000_00000_00000_00000_00000_00100")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(1, 28).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_trailing_0s_1() {
+        let str = "0.00001_00000_00000";
         assert_eq!(
-            parse_str_radix_10("0.00001_00000_00000").unwrap().unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(10_000_000_000, 15).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_trailing_0s_2() {
+        let str = "0.00001_00000_00000_00000_00000_00000";
         assert_eq!(
-            parse_str_radix_10("0.00001_00000_00000_00000_00000_00000")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(100_000_000_000_000_000_000_000, 28).unpack()
+        );
+        assert_eq!(
+            parse_str_radix_10(str).unwrap().unpack(),
+            parse_str_radix_n(str, 10).unwrap().unpack()
         );
     }
 
     #[test]
     fn from_str_overflow_1() {
+        let str = "99999_99999_99999_99999_99999_99999.99999";
         assert_eq!(
-            parse_str_radix_10("99999_99999_99999_99999_99999_99999.99999"),
-            // The original implementation returned
-            //              Ok(10000_00000_00000_00000_00000_0000)
-            // Which is a bug!
+            parse_str_radix_10(str),
             Err(Error::from("Invalid decimal: overflow from too many digits"))
         );
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_overflow_2() {
-        assert!(
-            parse_str_radix_10("99999_99999_99999_99999_99999_11111.11111").is_err(),
-            // The original implementation is 'overflow from scale mismatch'
-            // but we got rid of that now
-        );
+        let str = "99999_99999_99999_99999_99999_11111.11111";
+        assert!(parse_str_radix_10(str).is_err());
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_overflow_3() {
-        assert!(
-            parse_str_radix_10("99999_99999_99999_99999_99999_99994").is_err() // We could not get into 'overflow when rounding' or 'overflow from carry'
-                                                                               // in the original implementation because the rounding logic before prevented it
-        );
+        let str = "99999_99999_99999_99999_99999_99994";
+        assert!(parse_str_radix_10(str).is_err());
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_overflow_4() {
+        let str = "99999_99999_99999_99999_99999_999.99";
         assert_eq!(
             // This does not overflow, moving the decimal point 1 more step would result in
             // 'overflow from too many digits'
-            parse_str_radix_10("99999_99999_99999_99999_99999_999.99")
-                .unwrap()
-                .unpack(),
+            parse_str_radix_10(str).unwrap().unpack(),
             Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 0).unpack()
         );
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_edge_cases_1() {
-        assert_eq!(parse_str_radix_10(""), Err(Error::from("Invalid decimal: empty")));
+        let str = "";
+        assert_eq!(parse_str_radix_10(str), Err(Error::from("Invalid decimal: empty")));
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_edge_cases_2() {
+        let str = "0.1.";
         assert_eq!(
-            parse_str_radix_10("0.1."),
+            parse_str_radix_10(str),
             Err(Error::from("Invalid decimal: two decimal points"))
         );
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_edge_cases_3() {
+        let str = "_";
         assert_eq!(
-            parse_str_radix_10("_"),
+            parse_str_radix_10(str),
             Err(Error::from("Invalid decimal: must start lead with a number"))
         );
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_edge_cases_4() {
+        let str = "1?2";
         assert_eq!(
-            parse_str_radix_10("1?2"),
+            parse_str_radix_10(str),
             Err(Error::from("Invalid decimal: unknown character"))
         );
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 
     #[test]
     fn from_str_edge_cases_5() {
+        let str = ".";
         assert_eq!(
-            parse_str_radix_10("."),
+            parse_str_radix_10(str),
             Err(Error::from("Invalid decimal: no digits found"))
         );
+        assert_eq!(parse_str_radix_10(str), parse_str_radix_n(str, 10));
     }
 }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3038,6 +3038,9 @@ fn it_can_parse_different_radix() {
         ("78", 10, true, "78"),
         ("78", 8, false, ""),
         ("101", 2, true, "5"),
+        ("22222", 3, true, "242"),
+        ("1234", 5, true, "194"),
+        ("a_a_a", 11, true, "1330"),
         // Parse base 2
         ("1111_1111_1111_1111_1111_1111_1111_1111", 2, true, "4294967295"),
         // Max supported value


### PR DESCRIPTION
This commit applied the techniques used in optimizing parse_str_radix_10
1. single pass computation
2. 64 bit arithmetic with 128 bit fallback

Without the tail call optimizations, the improvement is:

cargo bench --bench lib_benches -- decimal_from_str_radix_n

```
Baseline:
decimal_from_str_radix_n ... bench:     368 ns/iter (+/- 5) [M1 Pro]
decimal_from_str_radix_n ... bench:     328 ns/iter (+/- 3) [Ryzen 3990x]

Current:
decimal_from_str_radix_n ... bench:     180 ns/iter (+/- 1) [M1 Pro]
decimal_from_str_radix_n ... bench:     218 ns/iter (+/- 8) [Ryzen 3990x]
```